### PR TITLE
UI + Gateway sepration changes (#rakesh)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,7 +93,12 @@
       "name": "jhipster generate sample-dev",
       "program": "${workspaceFolder}/bin/jhipster.cjs",
       "timeout": 100000,
-      "args": ["-d", "--skip-checks", "--skip-git", "--skip-cache"],
+      "args": [
+        "-d",
+        "--skip-checks",
+        "--skip-git",
+        "--skip-cache"
+      ],
       "cwd": "${workspaceFolder}/tmp/test",
       "console": "integratedTerminal"
     },
@@ -103,7 +108,10 @@
       "name": "jhipster generate sample-ci-cd",
       "program": "${workspaceFolder}/bin/jhipster.cjs",
       "timeout": 100000,
-      "args": ["ci-cd", "-d"],
+      "args": [
+        "ci-cd",
+        "-d"
+      ],
       "cwd": "${workspaceFolder}/tmp/test",
       "console": "integratedTerminal"
     },
@@ -113,7 +121,17 @@
       "name": "jhipster generate sample-dev from jdl",
       "program": "${workspaceFolder}/bin/jhipster.cjs",
       "timeout": 100000,
-      "args": ["jdl", "${workspaceFolder}/example/jdl/nooauth.jdl", "-d", "--skip-checks", "--skip-git", "--skip-cache", "--skip-jhipster-dependencies", "--skip-install"],
+      "args": [
+        "jdl",
+        "${workspaceFolder}/example/jdl/client.jdl",
+        "-d",
+        "--skip-checks",
+        "--skip-git",
+        "--skip-cache",
+        "--skip-jhipster-dependencies",
+        "--skip-install",
+        // "--skip-server"
+      ],
       "cwd": "${workspaceFolder}/tmp/test",
       "console": "integratedTerminal"
     },
@@ -137,7 +155,9 @@
       "internalConsoleOptions": "neverOpen",
       "name": "generate sample from angular workflow",
       "program": "${workspaceFolder}/test-integration/scripts/12-generate-sample.js",
-      "args": ["${input:angularSample}"],
+      "args": [
+        "${input:angularSample}"
+      ],
       "console": "integratedTerminal"
     },
     {
@@ -146,7 +166,9 @@
       "internalConsoleOptions": "neverOpen",
       "name": "generate sample from react workflow",
       "program": "${workspaceFolder}/test-integration/scripts/12-generate-sample.js",
-      "args": ["${input:reactSample}"],
+      "args": [
+        "${input:reactSample}"
+      ],
       "console": "integratedTerminal"
     },
     {
@@ -155,7 +177,9 @@
       "internalConsoleOptions": "neverOpen",
       "name": "generate sample from vue workflow",
       "program": "${workspaceFolder}/test-integration/scripts/12-generate-sample.js",
-      "args": ["${input:vueSample}"],
+      "args": [
+        "${input:vueSample}"
+      ],
       "console": "integratedTerminal"
     },
     {
@@ -164,7 +188,9 @@
       "internalConsoleOptions": "neverOpen",
       "name": "generate sample from daily-ms-oauth2 workflow",
       "program": "${workspaceFolder}/test-integration/scripts/12-generate-sample.js",
-      "args": ["${input:daily-ms-oauth2Sample}"],
+      "args": [
+        "${input:daily-ms-oauth2Sample}"
+      ],
       "console": "integratedTerminal"
     },
     {
@@ -173,7 +199,9 @@
       "internalConsoleOptions": "neverOpen",
       "name": "generate sample from daily-neo4j workflow",
       "program": "${workspaceFolder}/test-integration/scripts/12-generate-sample.js",
-      "args": ["${input:daily-neo4jSample}"],
+      "args": [
+        "${input:daily-neo4jSample}"
+      ],
       "console": "integratedTerminal"
     }
   ]

--- a/example/jdl/client.jdl
+++ b/example/jdl/client.jdl
@@ -1,0 +1,86 @@
+application {
+  config {
+    baseName client,
+    applicationType gateway,
+    packageName com.cmi.tic,
+    authenticationType oauth2,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType no,
+    clientFramework react,
+    serverPort 3000
+    blueprints [react]
+  }
+}
+
+application {
+  config {
+    baseName gateway
+    applicationType gateway,
+    packageName com.cmi.tic,
+    authenticationType oauth2,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType eureka,
+    clientFramework no,
+    serverPort 8000
+  }
+}
+
+application {
+  config {
+    baseName backend
+    applicationType microservice,
+    packageName com.cmi.tic,
+    authenticationType oauth2,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType eureka,
+    clientFramework no,
+    serverPort 8089
+  }
+}
+
+
+
+communication {
+  client "client"
+  server "gateway"
+  framework "rest-api"
+  type "sync"
+}
+
+communication {
+  client "client"
+  server "backend"
+  framework "rest-api"
+  type "sync"
+}
+
+communication {
+  client "gateway"
+  server "backend"
+  framework "rest-api"
+  type "sync"
+}
+
+communication {
+  client "backend"
+  server "gateway"
+  framework "rest-api"
+  type "sync"
+}
+
+deployment {
+  deploymentType kubernetes
+  appsFolders [client, gateway, backend]
+  dockerRepositoryName "raxkumar"
+  serviceDiscoveryType eureka
+  kubernetesNamespace k8s
+  kubernetesServiceType Ingress
+  ingressDomain "shopt.gq"
+  istio true
+  kubernetesUseDynamicStorage true
+  kubernetesStorageClassName "demosc"
+  kubernetesStorageProvisioner "ebs.csi.aws.com"
+}

--- a/example/jdl/microservices.jdl
+++ b/example/jdl/microservices.jdl
@@ -1,0 +1,42 @@
+application {
+  config {
+    baseName gateway
+    applicationType gateway,
+    packageName com.cmi.tic,
+    authenticationType no,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType no,
+    clientFramework no,
+    serverPort 8000
+  }
+}
+
+application {
+  config {
+    baseName gomicro
+    applicationType microservice,
+    packageName com.cmi.tic,
+    authenticationType no,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType no,
+    clientFramework no,
+    serverPort 9000
+    blueprints [gomicro]
+  }
+}
+
+application {
+  config {
+    baseName backend
+    applicationType microservice,
+    packageName com.cmi.tic,
+    authenticationType no,
+    databaseType no,
+    prodDatabaseType no,
+    serviceDiscoveryType no,
+    clientFramework no,
+    serverPort 8089
+  }
+}

--- a/generators/communications/files.mjs
+++ b/generators/communications/files.mjs
@@ -26,12 +26,14 @@ export default async function writeCommunicationsFilesTask({ application }) {
   // if (this.communicationsAsyncTypePulsar) {
   // }
 
-  if (this.communicationsFrameworkRestAPI) {
+  if (this.communicationsFrameworkRestAPI ) {
+    if( this.jhipsterConfig.authenticationType === 'oauth2' )
     this.fs.copyTpl(
       this.templatePath(`${REST_API_MAIN_DIR}/java/package/config/webClient/AccessToken.java.ejs`),
       this.destinationPath(`${SERVER_MAIN_SRC_DIR}`.concat(this.jhipsterConfig.packageFolder).concat('/config/webClient/AccessToken.java')),
       {
         packageName: this.jhipsterConfig.packageName,
+        authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
       }
     );
 
@@ -42,6 +44,7 @@ export default async function writeCommunicationsFilesTask({ application }) {
       ),
       {
         packageName: this.jhipsterConfig.packageName,
+        authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
       }
     );
   }
@@ -95,6 +98,7 @@ export default async function writeCommunicationsFilesTask({ application }) {
             packageName: this.jhipsterConfig.packageName,
             capitalizeServerName,
             serverName: communications[i].server.toLowerCase(),
+            authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
           }
         );
         this.fs.copyTpl(
@@ -108,6 +112,7 @@ export default async function writeCommunicationsFilesTask({ application }) {
             packageName: this.jhipsterConfig.packageName,
             capitalizeServerName,
             serverName: communications[i].server.toLowerCase(),
+            authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
           }
         );
       }
@@ -158,6 +163,7 @@ export default async function writeCommunicationsFilesTask({ application }) {
           {
             packageName: this.jhipsterConfig.packageName,
             serverName: communications[i].server.toLowerCase(),
+            authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
           }
         );
         this.fs.copyTpl(
@@ -168,6 +174,7 @@ export default async function writeCommunicationsFilesTask({ application }) {
           {
             packageName: this.jhipsterConfig.packageName,
             serverName: communications[i].server.toLowerCase(),
+            authenticationTypeOauth2: this.jhipsterConfig.authenticationType == 'oauth2'
           }
         );
       }

--- a/generators/communications/templates/rest-api/src/main/java/package/web/rest/ClientResource.java.ejs
+++ b/generators/communications/templates/rest-api/src/main/java/package/web/rest/ClientResource.java.ejs
@@ -1,6 +1,7 @@
 package <%= packageName %>.web.rest.comm;
-
+<%_ if(authenticationTypeOauth2) { _%>
 import <%= packageName %>.config.webClient.AccessToken;
+<%_ } _%>
 import <%= packageName %>.config.webClient.WebClientConfig;
 
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ public class ClientResource<%= capitalizeServerName %> {
     @Autowired
     private WebClientConfig webClient;
 
+    <%_ if(authenticationTypeOauth2) { _%>
     @Autowired
     private AccessToken oAuthToken;
 
@@ -32,12 +34,18 @@ public class ClientResource<%= capitalizeServerName %> {
         this.webClient = webClientConfig;
         this.oAuthToken = oAuth;
     }
+    <%_ } else {_%>
+    public ClientResource<%= capitalizeServerName %>(WebClientConfig webClientConfig) {
+        this.webClient = webClientConfig;
+    }
+    <%_ } _%>
 
 
     @GetMapping("/services/<%= serverName %>")
     public Mono<ResponseEntity<Map<String,String>>> getClient() {
         try {
             Map<String,String> response = new HashMap<>();
+            <%_ if(authenticationTypeOauth2) { _%>
             String accessToken = oAuthToken.getToken();
             if(accessToken.isEmpty() || accessToken.isBlank() ){
                 log.error("No access token found");
@@ -45,12 +53,15 @@ public class ClientResource<%= capitalizeServerName %> {
                 response.put("cause","NO_ACCESS_TOKEN");
                 return  Mono.just(ResponseEntity.accepted().body(response));
             }
+            <%_ } _%>
             return webClient
                 .serviceWebClient()
                 .build()
                 .get()
                 .uri("http://<%= serverName %>/api/services/<%= serverName %>")
+                <%_ if(authenticationTypeOauth2) { _%>
                 .header(HttpHeaders.AUTHORIZATION, TOKEN_TYPE + accessToken)
+                <%_ } _%>
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {
                 }).flatMap(hashmap -> {

--- a/generators/communications/templates/rest-api/src/test/java/package/web/rest/ClientResourceUT.java.ejs
+++ b/generators/communications/templates/rest-api/src/test/java/package/web/rest/ClientResourceUT.java.ejs
@@ -1,6 +1,8 @@
 package <%= packageName %>.web.rest.comm;
 
+<%_ if(authenticationTypeOauth2) { _%>
 import <%= packageName %>.config.webClient.AccessToken;
+<%_ } _%>
 import <%= packageName %>.config.webClient.WebClientConfig;
 
 import org.junit.jupiter.api.Assertions;
@@ -21,8 +23,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ClientResource<%= capitalizeServerName %>UT {
+    <%_ if(authenticationTypeOauth2) { _%>
     @Mock
     private AccessToken oAuth;
+    <%_ } _%>
 
     @Mock
     private WebClientConfig webClientConfig;
@@ -30,13 +34,21 @@ class ClientResource<%= capitalizeServerName %>UT {
     private ClientResource<%= capitalizeServerName %> clientResource<%= capitalizeServerName %>;
 
     @BeforeEach
+    <%_ if(authenticationTypeOauth2) { _%>
     void init(){
         clientResource<%= capitalizeServerName %> = new ClientResource<%= capitalizeServerName %>(webClientConfig,oAuth);
     }
+    <%_ } else { _%>
+    void init() {
+        clientResource<%= capitalizeServerName %> = new ClientResource<%= capitalizeServerName %>(webClientConfig);
+    }
+    <%_ } _%>
 
     @Test
     void getClientNullCheck(){
+        <%_ if(authenticationTypeOauth2) { _%>
         when(oAuth.getToken()).thenReturn("");
+        <%_ } _%>
         Mono<ResponseEntity<Map<String, String>>> result = clientResource<%= capitalizeServerName %>.getClient();
         ResponseEntity<Map<String, String>> statusCode =  result.block();
         Assertions.assertEquals(statusCode.getStatusCode(), HttpStatusCode.valueOf(202));
@@ -44,7 +56,9 @@ class ClientResource<%= capitalizeServerName %>UT {
 
     @Test
     void getClient(){
+        <%_ if(authenticationTypeOauth2) { _%>
         when(oAuth.getToken()).thenReturn("access_token");
+        <%_ } _%>
         when(webClientConfig.serviceWebClient()).thenReturn(mockServiceWebClient());
         Mono<ResponseEntity<Map<String, String>>> response = clientResource<%= capitalizeServerName %>.getClient();
         ResponseEntity<Map<String, String>> statusCode =  response.block();

--- a/generators/kubernetes/files.mjs
+++ b/generators/kubernetes/files.mjs
@@ -63,7 +63,7 @@ export function writeFiles() {
         if (this.app.searchEngine === ELASTICSEARCH) {
           this.writeFile('db/elasticsearch.yml.ejs', `${appOut}/${appName}-elasticsearch.yml`);
         }
-        if (this.app.applicationType === GATEWAY || this.app.applicationType === MONOLITH) {
+        if (this.app.applicationType === GATEWAY || this.app.applicationType === MONOLITH || this.app.applicationType === MICROSERVICE) {
           if (this.istio) {
             this.writeFile('istio/gateway.yml.ejs', `${appOut}/${appName}-gateway.yml`);
           } else if (this.kubernetesServiceType === 'Ingress') {
@@ -120,13 +120,14 @@ export function writeFiles() {
       }
     },
 
-    // write's keycloak files with istio if istio is true  @cmi-tic-craxkumar
+    // write's keycloak files with istio if istio and keycloak is true  @cmi-tic-craxkumar
     writeKeycloakWithIstio() {
-      if (!this.istio) return;
-      const keycloakOut = 'keycloak'.concat('-', suffix);
-      this.writeFile('keycloak/keycloak-destination-rule.yml.ejs', `${keycloakOut}/keycloak-destination-rule.yml`);
-      this.writeFile('keycloak/keycloak-virtual-service.yml.ejs', `${keycloakOut}/keycloak-virtual-service.yml`);
-      this.writeFile('keycloak/keycloak-gateway.yml.ejs', `${keycloakOut}/keycloak-gateway.yml`);
+      if (this.istio && this.useKeycloak) {
+        const keycloakOut = 'keycloak'.concat('-', suffix);
+        this.writeFile('keycloak/keycloak-destination-rule.yml.ejs', `${keycloakOut}/keycloak-destination-rule.yml`);
+        this.writeFile('keycloak/keycloak-virtual-service.yml.ejs', `${keycloakOut}/keycloak-virtual-service.yml`);
+        this.writeFile('keycloak/keycloak-gateway.yml.ejs', `${keycloakOut}/keycloak-gateway.yml`);
+      }
     },
 
     // write's keycloak files if useKeycloak is true @cmi-tic-craxkumar

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -52,6 +52,7 @@ spec:
                         - <%= app.baseName.toLowerCase() %>
                 topologyKey: kubernetes.io/hostname
               weight: 100
+<%_ if (app.clientFramework === 'no') { _%>
       initContainers:
         - name: init-ds
           image: busybox:latest
@@ -86,12 +87,16 @@ spec:
                   echo "DB is not yet reachable;sleep for 10s before retry"
                   sleep 10
                 done
+<%_ } _%>        
       containers:
       - name: <%= app.baseName.toLowerCase() %>-app
         image: <%= app.targetImageName %>
+<%_ if (app.clientFramework === 'no') { _%>
         env:
         - name: SPRING_PROFILES_ACTIVE
-          value: prod
+          value: prod,api-docs
+        - name: JHIPSTER_CORS_ALLOWED_ORIGINS
+          value: '<%= appConfigs.map(config => "http://" + config.baseName + "." + kubernetesNamespace + "." + ingressDomain).join(",") %>'
       <%_ if (minikube) { _%>
         - name: MINIKUBE_IP
           valueFrom:
@@ -352,6 +357,7 @@ spec:
       <%_ } _%> 
         - name: GO_MICRO_SERVICE_REGISTRY_URL
           value: http://admin:$(JHIPSTER_REGISTRY_PASSWORD)@jhipster-registry.<%= kubernetesNamespace %>.svc.cluster.local:8761/eureka/apps/
+<%_ } _%>
         resources:
           requests:
             memory: "1Gi"
@@ -359,6 +365,11 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "1"
+<%_ if (app.clientFramework === 'react' || app.clientFramework === 'angular' || app.clientFramework === 'vue') { _%>    
+        ports:
+        - name: http
+          containerPort: 80
+<%_ } else {_%>
         ports:
         - name: <%= (externalLB && app.applicationTypeGateway) ? app.baseName.toLowerCase() + '-port' : 'http' %>
           containerPort: <%= app.serverPort %>
@@ -374,3 +385,6 @@ spec:
             path: /management/health/liveness
             port: <%= (externalLB && app.applicationTypeGateway) ? app.baseName.toLowerCase() + '-port' : 'http' %>
           initialDelaySeconds: 120
+  <%_ } _%>
+
+

--- a/generators/kubernetes/templates/service.yml.ejs
+++ b/generators/kubernetes/templates/service.yml.ejs
@@ -42,7 +42,7 @@ spec:
   - name: http
 <%_ if (!app.serviceDiscoveryAny) { _%>
     port: 80
-    targetPort: <%= app.serverPort %>
+    targetPort: <%= (app.clientFramework === 'react' || app.clientFramework === 'angular' || app.clientFramework === 'vue')  ? 80 :  app.serverPort  %>
 <%_ } else { _%>
     port: <%= app.serverPort %>
   <%_ if (minikube && app.applicationTypeGateway) { _%>

--- a/generators/liquibase/files.mts
+++ b/generators/liquibase/files.mts
@@ -53,12 +53,12 @@ export const liquibaseFiles: WriteFileSection<LiquibaseGenerator, CommonClientSe
       ],
     },
     {
-      condition: generator => Boolean(generator.generateUserManagement),
+      condition: generator => (Boolean(generator.generateUserManagement) && (( generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession ))),
       path: SERVER_MAIN_RES_DIR,
       templates: ['config/liquibase/data/user.csv', 'config/liquibase/data/user_authority.csv'],
     },
     {
-      condition: generator => Boolean(generator.generateBuiltInAuthorityEntity),
+      condition: generator => (Boolean(generator.generateBuiltInAuthorityEntity) && (( generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession ))),
       path: SERVER_MAIN_RES_DIR,
       templates: ['config/liquibase/data/authority.csv'],
     },

--- a/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/initial_schema_sql.xml.ejs
+++ b/generators/liquibase/templates/src/main/resources/config/liquibase/changelog/initial_schema_sql.xml.ejs
@@ -36,6 +36,7 @@
         The initial schema has the '00000000000001' id, so that it is over-written if we re-generate it.
     -->
     <changeSet id="00000000000001" author="jhipster">
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 <%_ if (generateBuiltInUserEntity) {
         const idField = user.primaryKey.fields[0];
 _%>
@@ -163,6 +164,7 @@ _%>
         </loadData>
   <%_ } _%>
         <dropDefaultValue tableName="<%= user.entityTableName %>" columnName="created_date" columnDataType="${datetimeType}"/>
+<%_ } _%>
 <%_ } _%>
     </changeSet>
 

--- a/generators/mongodb/files.mjs
+++ b/generators/mongodb/files.mjs
@@ -27,7 +27,7 @@ export const mongoDbFiles = {
       templates: ['config/DatabaseConfiguration.java'],
     },
     {
-      condition: generator => generator.generateBuiltInUserEntity,
+      condition: generator => (generator.generateBuiltInUserEntity && (generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession)),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: ['config/dbmigrations/InitialSetupMigration.java'],

--- a/generators/mongodb/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/mongodb/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -40,7 +40,9 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.elasticsearch.repository.config.Enable<% if (reactive) { %>Reactive<% } %>ElasticsearchRepositories;
 <%_ } _%>
 <%_ if (!reactive) { _%>
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+<%_ } _%>
 <%_ } _%>
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
@@ -65,7 +67,9 @@ import java.util.List;
 @Import(value = {MongoAutoConfiguration.class, MongoReactiveAutoConfiguration.class})
 <%_ } else { _%>
 @Import(value = MongoAutoConfiguration.class)
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 @EnableMongoAuditing(auditorAwareRef = "springSecurityAuditorAware")
+<%_ } _%>
 <%_ } _%>
 public class DatabaseConfiguration {
 

--- a/generators/server/entity-files.mjs
+++ b/generators/server/entity-files.mjs
@@ -191,22 +191,25 @@ export const dtoFiles = {
 const userFiles = {
   userFiles: [
     {
+      condition: (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: (data, file) => moveToJavaPackageSrcDir(data, file).replace('/User.java', `/${data.user.persistClass}.java`),
       templates: ['domain/User.java'],
     },
     {
+      condition: (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: (data, file) => moveToJavaPackageSrcDir(data, file).replace('/UserDTO.java', `/${data.user.dtoClass}.java`),
       templates: ['service/dto/UserDTO.java'],
     },
     {
+      condition: (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: (data, file) => moveToJavaPackageSrcDir(data, file).replace('/AdminUserDTO.java', `/${data.user.adminUserDto}.java`),
       templates: ['service/dto/AdminUserDTO.java'],
     },
     {
-      condition: data => data.generateBuiltInUserEntity,
+      condition: ((data => data.generateBuiltInUserEntity) && (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession)),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: [
@@ -217,7 +220,7 @@ const userFiles = {
       ],
     },
     {
-      condition: data => data.generateBuiltInUserEntity,
+      condition: ((data => data.generateBuiltInUserEntity) && (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession)),
       path: `${SERVER_TEST_SRC_DIR}package/`,
       renameTo: moveToJavaPackageTestDir,
       templates: [

--- a/generators/server/files.mjs
+++ b/generators/server/files.mjs
@@ -413,7 +413,7 @@ export const baseServerFiles = {
   serverJavaAuthConfig: [
     {
       condition: generator =>
-        !generator.reactive && (generator.databaseTypeSql || generator.databaseTypeMongodb || generator.databaseTypeCouchbase),
+        !generator.reactive && (generator.databaseTypeSql || generator.databaseTypeMongodb || generator.databaseTypeCouchbase) && ( generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: ['security/SpringSecurityAuditorAware.java'],

--- a/generators/server/files.mjs
+++ b/generators/server/files.mjs
@@ -163,7 +163,7 @@ const accountFiles = {
       ],
     },
     {
-      condition: data => data.generateUserManagement,
+      condition: ((data => data.generateUserManagement) && (generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession)),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: ['web/rest/vm/ManagedUserVM.java'],
@@ -186,6 +186,7 @@ const accountFiles = {
 const userManagementFiles = {
   userManagementFiles: [
     {
+      condition: generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession,
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: [
@@ -204,15 +205,18 @@ const userManagementFiles = {
       ],
     },
     {
+      condition: generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession,
       path: `${SERVER_TEST_SRC_DIR}package/`,
       renameTo: moveToJavaPackageTestDir,
       templates: ['service/MailServiceIT.java', 'security/DomainUserDetailsServiceIT.java'],
     },
     {
+      condition: generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession,
       path: SERVER_MAIN_RES_DIR,
       templates: ['templates/mail/activationEmail.html', 'templates/mail/creationEmail.html', 'templates/mail/passwordResetEmail.html'],
     },
     {
+      condition: generator => generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession,
       path: SERVER_TEST_RES_DIR,
       templates: [
         'templates/mail/activationEmail.html',
@@ -222,7 +226,7 @@ const userManagementFiles = {
       ],
     },
     {
-      condition: generator => !generator.enableTranslation,
+      condition: generator => !generator.enableTranslation && (generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession),
       path: SERVER_TEST_RES_DIR,
       templates: ['i18n/messages_en.properties'],
     },

--- a/generators/server/generator.mjs
+++ b/generators/server/generator.mjs
@@ -751,7 +751,7 @@ export default class JHipsterServerGenerator extends BaseApplicationGenerator {
             'backend:start': `./mvnw${excludeWebapp}`,
             'java:jar': './mvnw -ntp verify -DskipTests --batch-mode',
             'java:war': './mvnw -ntp verify -DskipTests --batch-mode -Pwar',
-            'java:docker': './mvnw -ntp verify -DskipTests -Pprod jib:dockerBuild',
+            'java:docker': './mvnw -ntp verify -DskipTests -Pprod,api-docs jib:dockerBuild',
             'java:docker:dev:arm64': 'npm run java:docker -- -Pdev,webapp -Djib-maven-plugin.architecture=arm64',
             'java:docker:arm64': 'npm run java:docker -- -Djib-maven-plugin.architecture=arm64',
             'backend:unit:test': `./mvnw -ntp${excludeWebapp} verify --batch-mode ${javaCommonLog} ${javaTestLog}`,

--- a/generators/server/support/update-languages.mts
+++ b/generators/server/support/update-languages.mts
@@ -19,6 +19,7 @@
 
 import type BaseGenerator from '../../base/index.mjs';
 import { type SpringBootApplication } from '../types.mjs';
+import fs from 'fs';
 
 type UpdateServerLanguagesTaskParam = { application: SpringBootApplication & { enableTranslation: true }; control: any };
 
@@ -35,10 +36,12 @@ export function updateLanguagesInMailServiceITTask(this: BaseGenerator, { applic
     newContent += `        "${language.languageTag}"${i !== languagesDefinition.length - 1 ? ',' : ''}\n`;
   });
   newContent += '        // jhipster-needle-i18n-language-constant - JHipster will add/remove languages in this array\n    };';
-
-  this.editFile(`${javaPackageTestDir}/service/MailServiceIT.java`, { ignoreNonExisting }, content =>
+  const filePath = `${javaPackageTestDir}/service/MailServiceIT.java`;
+  if (fs.existsSync(filePath)) {
+    this.editFile(`${javaPackageTestDir}/service/MailServiceIT.java`, { ignoreNonExisting }, content =>
     content.replace(/private.*static.*String.*languages.*\{([^}]*jhipster-needle-i18n-language-constant[^}]*)\};/g, newContent)
-  );
+    );
+  }
 }
 
 export default function updateLanguagesTask(this: BaseGenerator, taskParam: UpdateServerLanguagesTaskParam) {

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_imperative.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_imperative.java.ejs
@@ -190,7 +190,7 @@ public class SecurityConfiguration {
 <%_ if (communicationSpringWebsocket) { _%>
                     .requestMatchers("/websocket/**").authenticated()
 <%_ } _%>
-                    .requestMatchers("/v3/api-docs/**").hasAuthority(AuthoritiesConstants.ADMIN)
+                    .requestMatchers("/v3/api-docs/**").permitAll()
                     .requestMatchers("/management/health").permitAll()
                     .requestMatchers("/management/health/**").permitAll()
                     .requestMatchers("/management/info").permitAll()

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
@@ -274,7 +274,7 @@ public class SecurityConfiguration {
 <%_ if (!applicationTypeMicroservice) { _%>
                     .pathMatchers("/services/**").authenticated()
 <%_ } _%>
-                    .pathMatchers("/v3/api-docs/**").hasAuthority(AuthoritiesConstants.ADMIN)
+                    .pathMatchers("/v3/api-docs/**").permitAll()
                     .pathMatchers("/management/health").permitAll()
                     .pathMatchers("/management/health/**").permitAll()
                     .pathMatchers("/management/info").permitAll()

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -149,6 +149,7 @@ _%>
     }
 
     private ProblemDetailWithCause getProblemDetailWithCause(Throwable ex) {
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 <%_ if (!skipUserManagement) { _%>
         if(ex instanceof <%= packageName %>.service.EmailAlreadyUsedException)
             return new EmailAlreadyUsedException().getProblemDetailWithCause();
@@ -156,6 +157,7 @@ _%>
             return new LoginAlreadyUsedException().getProblemDetailWithCause();
         if(ex instanceof <%= packageName %>.service.InvalidPasswordException )
             return (ProblemDetailWithCause) new InvalidPasswordException().getBody();
+<%_ } _%>
 <%_ } _%>
         if(ex instanceof ErrorResponseException exp && exp.getBody() instanceof ProblemDetailWithCause)
             return (ProblemDetailWithCause) exp.getBody();

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -290,7 +290,7 @@ jhipster:
   <%_ if (microfrontend) { _%>
     # Ports <%= devServerPort + 1 %>-<%= devServerPort + 9 %> are allowed for microfrontend development
   <%_ } _%>
-    allowed-origins: "http://localhost:8100,https://localhost:8100,http://localhost:9000,https://localhost:9000<%_ if (!skipClient) { _%>,http://localhost:<%= devServerPort %>,https://localhost:<%= devServerPort %><%_ if (microfrontend) { for (let port = 1; port < 10; port++) { _%>,http://localhost:<%= devServerPort + port %>,https://localhost:<%= devServerPort + port %><%_ } _%><%_ } } _%>"
+    allowed-origins: "http://localhost:3000,https://localhost:4200,http://localhost:8100,https://localhost:8100,http://localhost:9000,https://localhost:9000<%_ if (!skipClient) { _%>,http://localhost:<%= devServerPort %>,https://localhost:<%= devServerPort %><%_ if (microfrontend) { for (let port = 1; port < 10; port++) { _%>,http://localhost:<%= devServerPort + port %>,https://localhost:<%= devServerPort + port %><%_ } _%><%_ } } _%>"
     # Enable CORS when running in GitHub Codespaces
     allowed-origin-patterns: 'https://*.githubpreview.dev'
     allowed-methods: "*"
@@ -305,13 +305,13 @@ jhipster:
 <%_ } else { _%>
   # CORS is disabled by default on microservices, as you should access them through a gateway.
   # If you want to enable it, please uncomment the configuration below.
-  # cors:
-  #   allowed-origins: "http://localhost:9000,https://localhost:9000"
-  #   allowed-methods: "*"
-  #   allowed-headers: "*"
-  #   exposed-headers: "Authorization,Link,X-Total-Count"
-  #   allow-credentials: true
-  #   max-age: 1800
+  cors:
+    allowed-origins: "http://localhost:3000,https://localhost:4200"
+    allowed-methods: "*"
+    allowed-headers: "*"
+    exposed-headers: "Authorization,Link,X-Total-Count"
+    allow-credentials: true
+    max-age: 1800
 <%_ } _%>
 <%_ if (authenticationTypeJwt) { _%>
   security:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -214,6 +214,14 @@ server:
 # ===================================================================
 
 jhipster:
+  cors:
+    allowed-origins: 'http://localhost:3000,https://localhost:4200'
+    allowed-origin-patterns: 'https://*.githubpreview.dev'
+    allowed-methods: '*'
+    allowed-headers: '*'
+    exposed-headers: 'Authorization,Link,X-Total-Count,X-${jhipster.clientApp.name}-alert,X-${jhipster.clientApp.name}-error,X-${jhipster.clientApp.name}-params'
+    allow-credentials: true
+    max-age: 1800
 <%_ if (applicationTypeGateway && cacheProviderHazelcast && serviceDiscoveryAny) { _%>
   gateway:
     rate-limiting:

--- a/generators/sql/files.mjs
+++ b/generators/sql/files.mjs
@@ -30,7 +30,7 @@ export const sqlFiles = {
   ],
   reactiveJavaUserManagement: [
     {
-      condition: generator => generator.reactive && generator.generateBuiltInUserEntity,
+      condition: generator => ( generator.reactive && generator.generateBuiltInUserEntity && (generator.authenticationTypeJwt || generator.authenticationTypeOauth2 || generator.authenticationTypeSession)),
       path: `${SERVER_MAIN_SRC_DIR}package/`,
       renameTo: moveToJavaPackageSrcDir,
       templates: ['repository/UserSqlHelper_reactive.java', 'repository/rowmapper/UserRowMapper_reactive.java'],

--- a/generators/sql/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/sql/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -59,7 +59,9 @@ import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 import org.springframework.data.relational.core.dialect.RenderContextFactory;
 import org.springframework.data.relational.core.sql.render.SqlRenderer;
 <%_ } else { _%>
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+<%_ } _%>
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 <%_ } _%>
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -88,7 +90,9 @@ import java.util.UUID;
 @EnableR2dbcRepositories({<%- domains.map(domain => `"${domain}.repository"`).join(', ') %>})
 <%_ } else { _%>
 @EnableJpaRepositories({<%- domains.map(domain => `"${domain}.repository"`).join(', ') %>})
+<%_ if ( authenticationTypeJwt || authenticationTypeOauth2 || authenticationTypeSession ) { _%>
 @EnableJpaAuditing(auditorAwareRef = "springSecurityAuditorAware")
+<%_ } _%>
 <%_ } _%>
 @EnableTransactionManagement
 <%_ if (searchEngineElasticsearch) { _%>

--- a/jdl/exporters/applications/jhipster-application-exporter.ts
+++ b/jdl/exporters/applications/jhipster-application-exporter.ts
@@ -39,9 +39,23 @@ export function exportApplications(applications, content) {
 /**
  * Exports JDL a application to a JDL file in the current directory.
  * @param {Object} application - the formatted JHipster application to export.
+ * @param content
  */
-export function exportApplication(application) {
-  writeConfigFile(application);
+export function exportApplication(application, content) {
+  const applicationBaseName = application[GENERATOR_NAME].baseName;
+  if (doesFileExist(applicationBaseName)) {
+    throw new Error(
+      `A file named '${applicationBaseName}' already exists, so a folder of the same name can't be created for the application.`
+    );
+  }
+  createFolderIfItDoesNotExist(applicationBaseName);
+  const communicationsList = writeCommunicationFileForMultipleApplications(
+    content,
+    applicationBaseName,
+    path.join(applicationBaseName, 'comm.yo-rc.json')
+  );
+  application[GENERATOR_NAME].communicationsList = communicationsList;
+  writeConfigFile(application, path.join(applicationBaseName, '.yo-rc.json'));
 }
 
 /**

--- a/jdl/jdl-importer.ts
+++ b/jdl/jdl-importer.ts
@@ -117,7 +117,7 @@ function makeJDLImporter(content, configuration) {
       if (jdlObject.getApplicationQuantity() === 0 && jdlObject.getEntityQuantity() > 0) {
         importState.exportedEntities = importOnlyEntities(jdlObject, configuration);
       } else if (jdlObject.getApplicationQuantity() === 1) {
-        importState = importOneApplicationAndEntities(jdlObject, configuration);
+        importState = importOneApplicationAndEntities(jdlObject, configuration, content);
       } else {
         // Passing content to this method to write communication config file (comm.yo-rc.json) in each dir @cmi-tic-craxkumar
         importState = importApplicationsAndEntities(jdlObject, configuration, content);
@@ -218,7 +218,7 @@ function importOnlyEntities(jdlObject, configuration) {
   return exportJSONEntities(jsonEntities, configuration);
 }
 
-function importOneApplicationAndEntities(jdlObject, configuration) {
+function importOneApplicationAndEntities(jdlObject, configuration, content) {
   const { skipFileGeneration, forceNoFiltering } = configuration;
 
   const importState: ImportState = {
@@ -228,8 +228,9 @@ function importOneApplicationAndEntities(jdlObject, configuration) {
     exportedDeployments: [],
   };
   const formattedApplication = formatApplicationToExport(jdlObject.getApplications()[0], configuration);
-  if (!skipFileGeneration) {
-    exportApplication(formattedApplication);
+  // Changed the condition to enable the genration of .yo-rc.json & comm.yo-rc.json files @cmi-tic-craxkumar
+  if (skipFileGeneration) {
+    exportApplication(formattedApplication, content);
   }
   importState.exportedApplications.push(formattedApplication);
   const jdlApplication = jdlObject.getApplications()[0];


### PR DESCRIPTION
1. added new example jdl files.
2. solved issues with oauth2 -> no feature.
3. enable cors in application.properties files for prod and dev profile in server sub-generator.
4. enable Istio gateway for micro service as well.
5. update deployment and service k8s manifest files for client after sepration.
6. enabled api-docs(swagger) profile in deployment k8s manifest file.
7. disable protection of api-docs(swagger).
8. enabled generation of comm.yo-rc.json file for single application as well.